### PR TITLE
Update installation instructions now that dsc is in conda-forge.

### DIFF
--- a/installation/index.ipynb
+++ b/installation/index.ipynb
@@ -96,65 +96,64 @@
     "kernel": "SoS"
    },
    "source": [
-    "## 3. Install Python dependencies\n",
+    "## 3. Install (or upgrade) DSC\n",
     "\n",
-    "DSC uses [several Python modules](FAQ/Implementation_Details.html). We provide two sets of installation instructions: Python installed with `conda` (*i.e.*, Anaconda or Miniconda), and Python not installed with `conda`. \n",
+    "We provide two sets of installation instructions: Python installed with `conda` (*i.e.*, Anaconda or Miniconda), and Python not installed with `conda`.\n",
     "\n",
     "\n",
     "### 3a. If Python is installed with `conda` (Anaconda or Miniconda)\n",
     "\n",
-    "Install the modules required by DSC. First run\n",
+    "Using `conda`, install DSC from the conda-forge channel:\n",
     "\n",
     "```\n",
-    "conda install -c conda-forge fasteners python-xxhash pyarrow billiard\n",
+    "conda install -c conda-forge dsc\n",
     "```\n",
     "\n",
-    "then run\n",
-    "\n",
-    "```\n",
-    "conda install cython numpy pandas sqlalchemy msgpack-python sympy numexpr h5py \n",
-    "conda install psutil networkx pydotplus pyyaml tqdm pygments pexpect graphviz imageio\n",
-    "```\n",
-    "\n",
-    "After running these `conda install` commands, run these commands to make sure you have the latest versions:\n",
-    "\n",
-    "```\n",
-    "conda update -c conda-forge fasteners python-xxhash pyarrow billiard\n",
-    "conda update cython numpy pandas sqlalchemy msgpack-python sympy numexpr h5py\n",
-    "conda update psutil networkx pydotplus pyyaml tqdm pygments pexpect graphviz imageio\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
     "### 3b. If Python is *not* installed with `conda`\n",
-    "\n",
-    "In this case, you can skip this step because the `pip` command below will automatically install the required packages. However, we caution that:\n",
-    "\n",
-    "* You must have both `C` and `Fortran` compilers (and accompanying libraries).\n",
-    "\n",
-    "* The `pip` command may take a long time to run because several packages will need to be built from source. \n",
-    "\n",
-    "* Installation of some packages may fail. In so, try running the same command again; *sometimes running the same `pip` command a second time works!*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "## 4. Install (or upgrade) DSC\n",
     "\n",
     "Run this command to install or upgrade DSC (and any Python dependencies that remain uninstalled):\n",
     "\n",
     "```\n",
     "pip install -U --upgrade-strategy only-if-needed dsc\n",
-    "```"
+    "```\n",
+    "\n",
+    "However, we caution that:\n",
+    "\n",
+    "* You must have both `C` and `Fortran` compilers (and accompanying libraries).\n",
+    "\n",
+    "* The `pip` command may take a long time to run because several packages will need to be built from source. \n",
+    "\n",
+    "* Installation of some packages may fail. If so, try running the same command again; *sometimes running the same `pip` command a second time works!*\n",
+    "\n",
+    "If you are having difficulty installing DSC and its dependnencies directly from source, we recommend switching to using `conda`. Since `conda` installs binary packages that have already been compiled, this saves you from having to configure the correct compiler settings on your local machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## 4. Install modules for network visualization of benchmarks (optional)\n",
+    "\n",
+    "If you'd like to be able to create a network visualization of your benchmarks, you'll need to install some additional Python modules. This is an entirely optional feature which will not affect the running of your DSC benchmarks.\n",
+    "\n",
+    "\n",
+    "### 3a. If Python is installed with `conda` (Anaconda or Miniconda)\n",
+    "\n",
+    "Run the following:\n",
+    "\n",
+    "```\n",
+    "conda install -c conda-forge python-graphviz imageio pillow\n",
+    "```\n",
+    "\n",
+    "### 3b. If Python is *not* installed with `conda`\n",
+    "\n",
+    "Run the following:\n",
+    "\n",
+    "```\n",
+    "pip install -U --upgrade-strategy only-if-needed graphviz imageio pillow\n",
+    "```\n"
    ]
   },
   {
@@ -294,17 +293,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SoS",
-   "language": "sos",
-   "name": "sos"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": "sos",
-   "file_extension": ".sos",
-   "mimetype": "text/x-sos",
-   "name": "sos",
-   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
-   "pygments_lexer": "sos"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   },
   "sos": {
    "celltoolbar": true,

--- a/installation/index.ipynb
+++ b/installation/index.ipynb
@@ -293,32 +293,28 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "SoS",
+   "language": "sos",
+   "name": "sos"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "codemirror_mode": "sos",
+   "file_extension": ".sos",
+   "mimetype": "text/x-sos",
+   "name": "sos",
+   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
+   "pygments_lexer": "sos"
   },
   "sos": {
    "celltoolbar": true,
    "default_kernel": "SoS",
    "kernels": [],
    "panel": {
-    "displayed": false,
+    "displayed": true,
     "height": 0,
     "style": "side"
    },
-   "version": "0.9.13.2"
+   "version": "0.17.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@gaow @pcarbo I've updated the installation instructions now that DSC is available as a binary on conda-forge.

https://anaconda.org/conda-forge/dsc

* I removed the section on installing DSC dependencies with conda. This is now done automatically with `conda install dsc` just like `pip`
* I added a section for installing the visualization packages and noted that this is optional

These new shorter instructions should implement a similar setup. The main difference is that the Python modules `billiard` and `cython` are not installed. Is there a reason that these would still need to be installed to use DSC?